### PR TITLE
Make vector tile generation work for OpenMapTiles v3.6.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM klokantech/tileserver-gl:v1.7.0
+FROM klokantech/tileserver-gl:v2.3.0
 
 RUN set -x \
     && rm -rf /var/lib/apt/lists/* \

--- a/docker-compose-config.yml
+++ b/docker-compose-config.yml
@@ -2,7 +2,10 @@ version: "2"
 services:
   generate-vectortiles:
     environment:
-      BBOX: "103.062, 0.807, 104.545, 1.823"
+      DIFF_MODE: "false"
+      BBOX: "103.062,0.807,104.545,1.823"
       OSM_AREA_NAME: "Singapore Metro Area"
+      QUICKSTART_MIN_ZOOM: "0"
+      QUICKSTART_MAX_ZOOM: "18"
       MIN_ZOOM: "0"
-      MAX_ZOOM: "20"
+      MAX_ZOOM: "18"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,4 +6,4 @@ services:
     ports:
       - 8000:80
     volumes:
-      - ./tiles:/tiles
+      - ./openmaptiles/data/tiles.mbtiles:/tiles/singapore.mbtiles


### PR DESCRIPTION
Fixes to ensure that vector tile building pipeline will work for OpenMapTiles v3.6.2 (https://github.com/openmaptiles/openmaptiles/releases/tag/v3.6.2):
- A max zoom of `18` is sufficient as you are only seeing individual blocks at zoom 18-19.
  - Tile generation only needs 3 hours instead of 3 days.
  - Also, the vector map tile generation becomes disastrous if max zoom is set to 19 or more.
- Related bug: https://github.com/openmaptiles/openmaptiles/issues/208