### PR TITLE
Include map tiles inside Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ RUN /config/jq.sh
 RUN mkdir -p /tiles \
     && curl -L https://github.com/Neo-Type/iOneMySgMap/releases/download/20180202/singapore.mbtiles -o /tiles/singapore.mbtiles
 
+EXPOSE 8080
+RUN sed -e 's@ 80 @ 8080 @' -i /usr/src/app/run.sh
 
 ENTRYPOINT []
 CMD ["/usr/src/app/run.sh", "--config=/config/config.json"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM klokantech/tileserver-gl:v2.3.0
 
 RUN set -x \
-    && rm -rf /var/lib/apt/lists/* \
     && apt-get update \
-    && apt-get install -y jq curl
+    && apt-get install -y jq curl \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /config
 
@@ -14,6 +14,10 @@ RUN set -x \
 COPY config/config.json /config/config.json
 COPY config/jq.sh /config/jq.sh
 RUN /config/jq.sh
+
+RUN mkdir -p /tiles \
+    && curl -L https://github.com/Neo-Type/iOneMySgMap/releases/download/20180202/singapore.mbtiles -o /tiles/singapore.mbtiles
+
 
 ENTRYPOINT []
 CMD ["/usr/src/app/run.sh", "--config=/config/config.json"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,9 @@ COPY config/config.json /config/config.json
 COPY config/jq.sh /config/jq.sh
 RUN /config/jq.sh
 
+ARG MAP_TILES_VERSION 20180202
 RUN mkdir -p /tiles \
-    && curl -L https://github.com/Neo-Type/iOneMySgMap/releases/download/20180202/singapore.mbtiles -o /tiles/singapore.mbtiles
+    && curl -L https://github.com/Neo-Type/iOneMySgMap/releases/download/${MAP_TILES_VERSION}/singapore.mbtiles -o /tiles/singapore.mbtiles
 
 EXPOSE 8080
 RUN sed -e 's@ 80 @ 8080 @' -i /usr/src/app/run.sh


### PR DESCRIPTION
Changes to allow this image to work on an OpenShift environment ;)

1. The environment does not support listening on port 80 (must use non-privileged port)
2. Fix a minor issue of apt cache not being cleared after `apt-get update`
3. Include Singapore map tiles directly. You will probably want to version the Docker image with the map tiles version.